### PR TITLE
fix: news image size

### DIFF
--- a/blocks/news/news.js
+++ b/blocks/news/news.js
@@ -19,7 +19,7 @@ export function createNewsCard(newsItem, classPrefix, large = false) {
     newsItem.image,
     newsItem.imageAlt,
     false,
-    [{ width: 750 }],
+    [{ width: 500 }],
   ).outerHTML;
 
   cardContent.innerHTML = `


### PR DESCRIPTION
Smaller news image size

Test URLs:
- Before: https://main--fcbayern--hlxsites.hlx.page/
- After: https://news-image--fcbayern--hlxsites.hlx.page/
