### PR TITLE
Revert "fixed news theme styles"

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -503,7 +503,7 @@ main .section.highlight {
   background-color: white;
 }
 
-.newstheme a {
+.newstheme main a {
   font-family: var(--body-font-family);
   line-height: 1.1;
   font-weight: 600;
@@ -518,13 +518,13 @@ main .section.highlight {
   padding: 0px 2px !important;
 }
 
-.newstheme a:hover {
+.newstheme main a:hover {
   color: var(--colors-text-link);
   border-bottom: 2px solid currentcolor;
 }
 
 
-.newstheme :not(.news-header) h2 {
+.newstheme main :not(.news-header) h2 {
   font-family: var(--body-font-family);
   font-weight: 600;
   font-size: 20px;


### PR DESCRIPTION
This reverts commit 8af44650f85e0317049cb8bfe6775cfff9b3e533.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--fcbayern--hlxsites.hlx.page/
- After: https://newstheme-fix--fcbayern--hlxsites.hlx.page/
- Before: https://main--fcbayern--hlxsites.hlx.page/de/news/2022/09/lucas-hernandez-fehlt-mehrere-wochen-entwarnung-bei-benjamin-pavard
- After: https://newstheme-fix--fcbayern--hlxsites.hlx.page/de/news/2022/09/lucas-hernandez-fehlt-mehrere-wochen-entwarnung-bei-benjamin-pavard